### PR TITLE
add support for more (all) file formats besides .wav 

### DIFF
--- a/myointerface/SoundPlayer.cs
+++ b/myointerface/SoundPlayer.cs
@@ -6,16 +6,18 @@ using System.Threading.Tasks;
 
 namespace myointerface
 {
-    public class SoundPlayer : System.Media.SoundPlayer
+    public class SoundPlayer : System.Windows.Media.MediaPlayer
     {
+        Uri SoundLocation;
         public string File
         {
             get { return SoundLocation; }
         }
+
         public SoundPlayer(string SoundFile)
         {
-            this.SoundLocation = SoundFile;
-            this.Load();   
+            this.SoundLocation = new Uri(SoundFile);
+            this.Open(SoundLocation);   
         }
     }
 }

--- a/myointerface/myointerface.csproj
+++ b/myointerface/myointerface.csproj
@@ -36,9 +36,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Contracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=736440c9b414ea16, processorArchitecture=MSIL" />
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -57,9 +59,7 @@
     <Compile Include="MyoSoundControl.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SoundPlayer.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="SoundPlayer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -74,6 +74,9 @@
     <EmbeddedResource Include="MainWindow.resx">
       <DependentUpon>MainWindow.cs</DependentUpon>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
- Requires a reference to PresentationCore
- Please check out https://help.github.com/articles/checking-out-pull-requests-locally/ before doing anything stupid (like merging something untested).
- Not even remotely tested or even compiled (couldn´t be bothered) but should be fine since it is ObviouslyCorrect (tm) ;)
- This patch only adds support for more file formats, for direct interaction with the audio stream some sort of audio library is needed, which will be a bit more challenging than changing 3 lines of code. This is left as an exercise.
- If there is a problem (who knew...) it will most likely be related to the Uri creation. This is left as an exercise.
